### PR TITLE
/explore/catName/location header bug fix

### DIFF
--- a/pages/explore/[category]/[locationName].jsx
+++ b/pages/explore/[category]/[locationName].jsx
@@ -99,7 +99,7 @@ export default function ExploreLocation() {
   return (
     <>
       <Head>
-        { !router.isReady ? <title>First Maps</title> : <title>{`${titleStr} | First Maps`}</title> }
+        { !router.isReady ? <title>First Maps</title> : <title>{`${titleStr}`}</title> }
         <meta name="description" content={`First Maps: ${locationName}`} />
         <link rel="icon" href="/location-dot-solid.svg" />
       </Head>

--- a/pages/explore/index.jsx
+++ b/pages/explore/index.jsx
@@ -160,8 +160,6 @@ export default function Explore({ ...props }) {
     })()
   }, [])
 
-  // TODO: make each category have its own photo
-  
 
   // HANDLERS
   const handleClick = async (e) => {


### PR DESCRIPTION
now only shows "First Maps" once instead of twice
